### PR TITLE
Feat/헤더 부분 체크인원/전체 인원 기능 추가

### DIFF
--- a/src/api v2/ScheduleApiClient.ts
+++ b/src/api v2/ScheduleApiClient.ts
@@ -1,5 +1,10 @@
 import ApiClient from "./ApiClient";
-import { GetScheduleAttendeeRequest, GetScheduleAttendeeResponse } from "./ScheduleSchema";
+import {
+  GetScheduleAttendeeRequest,
+  GetScheduleAttendeeResponse,
+  GetScheduleCountOfDateRequest,
+  GetScheduleCountOfDateResponse,
+} from "./ScheduleSchema";
 
 export const getScheduleAttendee = async ({
   params,
@@ -12,6 +17,22 @@ export const getScheduleAttendee = async ({
   const response = await ApiClient.request({
     method: "GET",
     url: `/book/${attendanceBookId}/schedule?date=${date}&page=${pageable.page}&size=${pageable.page}&sort=${pageable.sort}`,
+  });
+
+  return response.data;
+};
+
+export const getScheduleCountOfDate = async ({
+  params,
+  attendanceBookId,
+}: {
+  params: GetScheduleCountOfDateRequest;
+  attendanceBookId: number;
+}): Promise<GetScheduleCountOfDateResponse> => {
+  const { date } = params;
+  const response = await ApiClient.request({
+    method: "GET",
+    url: `/book/${attendanceBookId}/schedule/count?date=${date}`,
   });
 
   return response.data;

--- a/src/api v2/ScheduleSchema.ts
+++ b/src/api v2/ScheduleSchema.ts
@@ -10,22 +10,24 @@ type ErrorResponse = ResponseBase & {
   timeStamp: string;
 };
 
+export type ScheduleData = {
+  scheduleId: number;
+  isTaught: boolean;
+  scheduleTime: string;
+  recordId: number;
+  recordTime: string;
+  sortTime: string;
+  recordStatus: STATUS | string; // Adjust based on actual enum values
+  attendeeId: number;
+  name: string;
+};
+
 export type ScheduleDataType = {
   content: {
     count: number;
     startTime: string;
     endTime: string;
-    schedules: {
-      scheduleId: number;
-      isTaught: boolean;
-      scheduleTime: string;
-      recordId: number;
-      recordTime: string;
-      sortTime: string;
-      recordStatus: STATUS | string; // Adjust based on actual enum values
-      attendeeId: number;
-      name: string;
-    }[];
+    schedules: ScheduleData[];
   }[];
   first: boolean;
   last: boolean;
@@ -35,7 +37,20 @@ export type ScheduleDataType = {
   empty: boolean;
 };
 
+export type ScheduleCountOfDateType = {
+  date: string;
+  totalCount: number;
+  checkedCount: number;
+};
+
 export type GetScheduleAttendeeResponse =
+  | ({
+      status: 200;
+      data: ScheduleDataType;
+    } & ResponseBase)
+  | ErrorResponse;
+
+export type GetScheduleCountOfDateResponse =
   | ({
       status: 200;
       data: ScheduleDataType;
@@ -49,4 +64,8 @@ export type GetScheduleAttendeeRequest = {
     size: number;
     sort: string[];
   };
+};
+
+export type GetScheduleCountOfDateRequest = {
+  date: string;
 };

--- a/src/api v2/ScheduleSchema.ts
+++ b/src/api v2/ScheduleSchema.ts
@@ -17,7 +17,7 @@ export type ScheduleData = {
   recordId: number;
   recordTime: string;
   sortTime: string;
-  recordStatus: STATUS | string; // Adjust based on actual enum values
+  recordStatus: STATUS;
   attendeeId: number;
   name: string;
 };

--- a/src/pages/books/book-check/BookCheck.tsx
+++ b/src/pages/books/book-check/BookCheck.tsx
@@ -1,7 +1,7 @@
 import Header from "./components/Header";
 import MainContents from "./components/MainContent";
 
-import { useContext, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { BookContext } from "@/context/BookContext";
 import { useParams, useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
@@ -9,6 +9,7 @@ import { getScheduleAttendee } from "@/api v2/ScheduleApiClient";
 import { ScheduleDataType } from "@/api v2/ScheduleSchema";
 import dayjs from "dayjs";
 import Bottom from "../components/Bottom";
+import { getScheduleCountOfDate } from "../../../api v2/ScheduleApiClient.ts";
 
 export default function BookCheck() {
   const context = useContext(BookContext);
@@ -18,6 +19,10 @@ export default function BookCheck() {
   const [searchParams] = useSearchParams();
   const bookName = searchParams.get("bookName");
   const [currentDate, setCurrentDate] = useState(dayjs()); // dayjs로 초기화
+  const [checkedScheduleCount, setCheckedScheduleCount] = useState<number>(0);
+  const [totalScheduleCount, setTotalScheduleCount] = useState<number>(0);
+
+  // const [checkedCount, setCheckedCount] = useState(0);
 
   const formattedDate = currentDate.format("YYYY-MM-DD"); // 데이터 값
 
@@ -30,6 +35,8 @@ export default function BookCheck() {
     setCurrentDate((prev) => prev.add(1, "day"));
   };
 
+  // 전체 데이터를 가지고 왔다고 가정
+  // checkedCount 상태 추가
   const { data: bookSchedules } = useQuery({
     queryKey: ["book-schedules", bookId, formattedDate],
     queryFn: async () =>
@@ -46,7 +53,36 @@ export default function BookCheck() {
       }),
   });
 
-  console.log(bookSchedules?.status === 200 && bookSchedules.data.content);
+  const { data: scheduleCount } = useQuery({
+    queryKey: ["schedule-count", bookId, formattedDate],
+    queryFn: async () =>
+      await getScheduleCountOfDate({
+        attendanceBookId: Number(bookId!),
+        params: {
+          date: formattedDate,
+        },
+      }),
+  });
+
+  // useEffect(() => {
+  //   if (scheduleCount?.data) {
+  //     setTotalScheduleCount(scheduleCount.data.totalCount);
+  //     setCheckedScheduleCount(scheduleCount.data.checkedCount);
+  //   }
+  // }, [scheduleCount]);
+
+  useEffect(() => {
+    if (bookSchedules?.data) {
+      setTotalScheduleCount(bookSchedules.data.numberOfElements);
+      const checkedCount = bookSchedules.data.content.reduce((total, schedules) => {
+        return total + schedules.schedules.filter((schedule) => schedule.recordStatus !== "PENDING").length;
+      }, 0);
+      setCheckedScheduleCount(checkedCount);
+    }
+  }, [scheduleCount]);
+
+  // console.log(bookSchedules?.status === 200 && bookSchedules.data.content);
+
   return (
     <section className="flex flex-col w-full scrollbar-hide custom-scrollbar-hide">
       <Header
@@ -56,11 +92,15 @@ export default function BookCheck() {
         handleNextDay={handleNextDay}
         currentDate={currentDate}
         formattedDate={formattedDate}
+        checkedScheduleCount={checkedScheduleCount}
+        totalScheduleCount={totalScheduleCount}
       />
       <MainContents
         bookSchedules={bookSchedules?.data as ScheduleDataType}
         currentDate={formattedDate}
         bookId={Number(bookId!)}
+        checkedScheduleCount={checkedScheduleCount}
+        setCheckedCount={setCheckedScheduleCount}
       />
       <div className="flex justify-between px-[44px] items-center w-full h-[92px] bg-bg-secondary" />
       <Bottom />

--- a/src/pages/books/book-check/BookCheck.tsx
+++ b/src/pages/books/book-check/BookCheck.tsx
@@ -9,7 +9,6 @@ import { getScheduleAttendee } from "@/api v2/ScheduleApiClient";
 import { ScheduleDataType } from "@/api v2/ScheduleSchema";
 import dayjs from "dayjs";
 import Bottom from "../components/Bottom";
-import { getScheduleCountOfDate } from "../../../api v2/ScheduleApiClient.ts";
 
 export default function BookCheck() {
   const context = useContext(BookContext);
@@ -21,8 +20,6 @@ export default function BookCheck() {
   const [currentDate, setCurrentDate] = useState(dayjs()); // dayjs로 초기화
   const [checkedScheduleCount, setCheckedScheduleCount] = useState<number>(0);
   const [totalScheduleCount, setTotalScheduleCount] = useState<number>(0);
-
-  // const [checkedCount, setCheckedCount] = useState(0);
 
   const formattedDate = currentDate.format("YYYY-MM-DD"); // 데이터 값
 
@@ -36,7 +33,7 @@ export default function BookCheck() {
   };
 
   // 전체 데이터를 가지고 왔다고 가정
-  // checkedCount 상태 추가
+  // checkedScheduleCount 상태 추가
   const { data: bookSchedules } = useQuery({
     queryKey: ["book-schedules", bookId, formattedDate],
     queryFn: async () =>
@@ -53,35 +50,20 @@ export default function BookCheck() {
       }),
   });
 
-  const { data: scheduleCount } = useQuery({
-    queryKey: ["schedule-count", bookId, formattedDate],
-    queryFn: async () =>
-      await getScheduleCountOfDate({
-        attendanceBookId: Number(bookId!),
-        params: {
-          date: formattedDate,
-        },
-      }),
-  });
-
-  // useEffect(() => {
-  //   if (scheduleCount?.data) {
-  //     setTotalScheduleCount(scheduleCount.data.totalCount);
-  //     setCheckedScheduleCount(scheduleCount.data.checkedCount);
-  //   }
-  // }, [scheduleCount]);
-
   useEffect(() => {
-    if (bookSchedules?.data) {
-      setTotalScheduleCount(bookSchedules.data.numberOfElements);
-      const checkedCount = bookSchedules.data.content.reduce((total, schedules) => {
+    if (bookSchedules?.status === 200) {
+      // CODE-REVIEW 이렇게 as 로 Casting 하지 않으면 타입 에러가 발생합니다..
+      const scheduleData = bookSchedules.data as ScheduleDataType;
+
+      setTotalScheduleCount(scheduleData.numberOfElements);
+      const checkedCount = scheduleData.content.reduce((total, schedules) => {
         return total + schedules.schedules.filter((schedule) => schedule.recordStatus !== "PENDING").length;
       }, 0);
       setCheckedScheduleCount(checkedCount);
     }
-  }, [scheduleCount]);
+  }, [bookSchedules]);
 
-  // console.log(bookSchedules?.status === 200 && bookSchedules.data.content);
+  // console.log(bookSchedules?.status === 200 && scheduleData.content);
 
   return (
     <section className="flex flex-col w-full scrollbar-hide custom-scrollbar-hide">

--- a/src/pages/books/book-check/components/Header.tsx
+++ b/src/pages/books/book-check/components/Header.tsx
@@ -1,11 +1,9 @@
-import { useState } from "react";
-import dayjs, { Dayjs } from "dayjs";
-import { motion, useScroll, useTransform, useSpring } from "framer-motion";
+import { Dayjs } from "dayjs";
+import { motion, useScroll, useSpring, useTransform } from "framer-motion";
 import { useNavigate } from "react-router-dom";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { updateRecordAll } from "@/api v2/RecordApiClient";
 import toast from "react-hot-toast";
-import { statusCheckAttendee } from "@/api v2/AttendeeApiClient";
 import { updateBookStatus } from "@/api v2/AttendanceBookApiClient";
 import { BookStatus } from "@/api v2/AttendanceBookSchema";
 
@@ -16,6 +14,8 @@ type HeaderProps = {
   handleNextDay: () => void;
   handlePreviousDay: () => void;
   currentDate: Dayjs;
+  checkedScheduleCount: number;
+  totalScheduleCount: number;
 };
 
 export default function Header(props: HeaderProps) {
@@ -26,6 +26,8 @@ export default function Header(props: HeaderProps) {
     handlePreviousDay,
     handleNextDay,
     formattedDate,
+    checkedScheduleCount,
+    totalScheduleCount,
   } = props;
 
   const navigate = useNavigate();
@@ -43,16 +45,8 @@ export default function Header(props: HeaderProps) {
   const iconY = useTransform(smoothScrollYProgress, [0, 0.15], [0, 8]);
   const iconOpacity = useTransform(smoothScrollYProgress, [0, 0.15], [1, 0]);
   const textOpacity = useTransform(smoothScrollYProgress, [0, 0.15], [1, 1]);
-  const headerHeight = useTransform(
-    smoothScrollYProgress,
-    [0, 0.2],
-    ["46px", "25px"]
-  );
-  const headerContainerHeight = useTransform(
-    smoothScrollYProgress,
-    [0, 0.2],
-    ["78px", "49px"]
-  );
+  const headerHeight = useTransform(smoothScrollYProgress, [0, 0.2], ["46px", "25px"]);
+  const headerContainerHeight = useTransform(smoothScrollYProgress, [0, 0.2], ["78px", "49px"]);
 
   const { mutate: recordAllMutation } = useMutation({
     mutationKey: [""],
@@ -112,32 +106,15 @@ export default function Header(props: HeaderProps) {
         <p className="text-[22px] font-bold" onClick={() => navigate("/book")}>
           {title}
         </p>
-        <img
-          src="/images/icons/ico-settings.svg"
-          alt="설정 아이콘"
-          width={32}
-          height={32}
-        />
+        <img src="/images/icons/ico-settings.svg" alt="설정 아이콘" width={32} height={32} />
       </div>
       {/* Calendar */}
       <div className="w-full flex h-10 justify-between items-center px-4 border-b border-bg-disabled">
-        <img
-          src="/images/icons/ico-arrow-left.svg"
-          alt="왼쪽 화살"
-          width={9}
-          height={9}
-          onClick={handlePreviousDay}
-        />
+        <img src="/images/icons/ico-arrow-left.svg" alt="왼쪽 화살" width={9} height={9} onClick={handlePreviousDay} />
         <p className="text-xl font-bold" data-value={formattedDate}>
           {displayDate}
         </p>
-        <img
-          src="/images/icons/ico-arrow-right.svg"
-          alt="오른쪽 화살"
-          width={9}
-          height={9}
-          onClick={handleNextDay}
-        />
+        <img src="/images/icons/ico-arrow-right.svg" alt="오른쪽 화살" width={9} height={9} onClick={handleNextDay} />
       </div>
       {/* SubHeader */}
       <motion.div
@@ -166,7 +143,8 @@ export default function Header(props: HeaderProps) {
               opacity: textOpacity,
             }}
           >
-            10/12
+            {checkedScheduleCount + "/" + totalScheduleCount}
+            {/*110/123*/}
           </motion.p>
         </motion.div>
         <div className="flex gap-2">
@@ -189,10 +167,7 @@ export default function Header(props: HeaderProps) {
                 width={16}
                 height={16}
               />
-              <motion.p
-                className="text-xs font-medium"
-                style={{ y: textY, opacity: textOpacity }}
-              >
+              <motion.p className="text-xs font-medium" style={{ y: textY, opacity: textOpacity }}>
                 {header.name}
               </motion.p>
             </motion.button>

--- a/src/pages/books/book-check/components/MainContent.tsx
+++ b/src/pages/books/book-check/components/MainContent.tsx
@@ -2,11 +2,7 @@ import { twMerge } from "tailwind-merge";
 
 import { ScheduleDataType } from "@/api v2/ScheduleSchema";
 import { getCurrentTimeParts, scheduleCheckformatTime } from "@/utils";
-import {
-  createRecord,
-  updateRecordLesson,
-  updateRecordStatus,
-} from "@/api v2/RecordApiClient";
+import { createRecord, updateRecordLesson, updateRecordStatus } from "@/api v2/RecordApiClient";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { STATUS } from "@/api v2/RecordSchema";
 
@@ -14,9 +10,23 @@ type IProps = {
   bookSchedules: ScheduleDataType;
   bookId: number;
   currentDate: string;
+  checkedScheduleCount: number;
+  setCheckedCount: (count: number) => void;
 };
+
+const handleStatusChange = (
+  currentStatus: STATUS,
+  targetStatus: Omit<STATUS, "PENDING">,
+  checkedCount: number,
+  setCheckedCount: (count: number) => void,
+) => {
+  // 상태 변화에 따른 checkedCount 조정
+  const adjustment = currentStatus === targetStatus ? -1 : currentStatus === "PENDING" ? 1 : 0;
+  setCheckedCount(checkedCount + adjustment);
+};
+
 export default function MainContents(props: IProps) {
-  const { bookId, bookSchedules, currentDate } = props;
+  const { bookId, bookSchedules, currentDate, checkedScheduleCount, setCheckedCount } = props;
 
   const queryClient = useQueryClient();
 
@@ -37,9 +47,7 @@ export default function MainContents(props: IProps) {
           scheduleId: scheduleId,
           attendDate: currentDate,
           attendTime: `${
-            getCurrentTimeParts().hour < 10
-              ? "0" + getCurrentTimeParts().hour
-              : getCurrentTimeParts().hour
+            getCurrentTimeParts().hour < 10 ? "0" + getCurrentTimeParts().hour : getCurrentTimeParts().hour
           }:${getCurrentTimeParts().minute}`,
           status: status,
         },
@@ -53,15 +61,7 @@ export default function MainContents(props: IProps) {
   });
   const { mutate: statusMutation } = useMutation({
     mutationKey: [""],
-    mutationFn: async ({
-      recordId,
-      scheduleId,
-      status,
-    }: {
-      recordId: number;
-      scheduleId: number;
-      status: STATUS;
-    }) =>
+    mutationFn: async ({ recordId, scheduleId, status }: { recordId: number; scheduleId: number; status: STATUS }) =>
       await updateRecordStatus({
         params: {
           attendanceBookId: bookId,
@@ -80,13 +80,7 @@ export default function MainContents(props: IProps) {
 
   const { mutate: lessonMutation } = useMutation({
     mutationKey: [""],
-    mutationFn: async ({
-      recordId,
-      isTaught,
-    }: {
-      recordId: number;
-      isTaught: boolean;
-    }) =>
+    mutationFn: async ({ recordId, isTaught }: { recordId: number; isTaught: boolean }) =>
       await updateRecordLesson({
         params: {
           attendanceBookId: bookId,
@@ -106,10 +100,7 @@ export default function MainContents(props: IProps) {
     <div className="w-full flex flex-col gap-4 justify-center items-center py-3 px-4 bg-bg-secondary scrollbar-hide custom-scrollbar-hide">
       {bookSchedules?.content?.map((content, index) => {
         return (
-          <div
-            key={index}
-            className="w-full text-left rounded-2xl bg-white px-6 pt-1 flex flex-col"
-          >
+          <div key={index} className="w-full text-left rounded-2xl bg-white px-6 pt-1 flex flex-col">
             <p className="text-s-bold text-text-secondary h-12 flex items-center">
               {scheduleCheckformatTime(content.startTime)}
             </p>
@@ -117,9 +108,7 @@ export default function MainContents(props: IProps) {
             {content.schedules.map((schedule) => {
               return (
                 <div className="w-full h-[56px] flex items-center justify-between px-2 ">
-                  <p className="font-bold  text-text-primary">
-                    {schedule.name}
-                  </p>
+                  <p className="font-bold  text-text-primary">{schedule.name}</p>
 
                   <div className="flex gap-4">
                     <div className="flex gap-2">
@@ -130,12 +119,24 @@ export default function MainContents(props: IProps) {
                           // statusMutation("REJECTED");`
 
                           if (schedule.recordId) {
-                            statusMutation({
-                              recordId: schedule.recordId,
-                              scheduleId: schedule.scheduleId,
-                              status: "ABSENT",
-                            });
+                            handleStatusChange(schedule.recordStatus, "ABSENT", checkedScheduleCount, setCheckedCount);
+                            if (schedule.recordStatus === "ABSENT") {
+                              statusMutation({
+                                recordId: schedule.recordId,
+                                scheduleId: schedule.scheduleId,
+                                status: "PENDING",
+                              });
+                            } else {
+                              statusMutation({
+                                recordId: schedule.recordId,
+                                scheduleId: schedule.scheduleId,
+                                status: "ABSENT",
+                              });
+                            }
                           } else {
+                            // recordId 가 없는 경우 이므로 무조건 checkedScheduleCount + 1
+                            setCheckedCount(checkedScheduleCount + 1);
+
                             recordMutation({
                               attendeeId: schedule.attendeeId,
                               scheduleId: schedule.scheduleId,
@@ -147,7 +148,7 @@ export default function MainContents(props: IProps) {
                           "rounded-lg text-sm w-[57px] h-[33px] flex items-center justify-center",
                           schedule.recordStatus === "ABSENT"
                             ? "bg-bg-destructive text-text-interactive-destructive"
-                            : "bg-bg-disabled text-text-disabled"
+                            : "bg-bg-disabled text-text-disabled",
                         )}
                       >
                         결석
@@ -155,12 +156,26 @@ export default function MainContents(props: IProps) {
                       <button
                         onClick={() => {
                           if (schedule.recordId) {
-                            statusMutation({
-                              recordId: schedule.recordId,
-                              scheduleId: schedule.scheduleId,
-                              status: "ATTEND",
-                            });
+                            handleStatusChange(schedule.recordStatus, "ATTEND", checkedScheduleCount, setCheckedCount);
+                            // 이미 출석인 경우 다시 누르면 PENDING 상태로 수정
+                            if (schedule.recordStatus === "ATTEND") {
+                              statusMutation({
+                                recordId: schedule.recordId,
+                                scheduleId: schedule.scheduleId,
+                                status: "PENDING",
+                              });
+                            } else {
+                              // ATTEND 상태가 아닌 경우 ATTEND 로 변경
+                              statusMutation({
+                                recordId: schedule.recordId,
+                                scheduleId: schedule.scheduleId,
+                                status: "ATTEND",
+                              });
+                            }
                           } else {
+                            // recordId 가 없는 경우 이므로 무조건 checkedScheduleCount + 1
+                            setCheckedCount(checkedScheduleCount + 1);
+
                             recordMutation({
                               attendeeId: schedule.attendeeId,
                               scheduleId: schedule.scheduleId,
@@ -172,7 +187,7 @@ export default function MainContents(props: IProps) {
                           "rounded-lg text-sm w-[57px] h-[33px] flex items-center justify-center",
                           schedule.recordStatus === "ATTEND"
                             ? "bg-bg-primary text-text-interactive-primary"
-                            : "bg-bg-disabled text-text-disabled"
+                            : "bg-bg-disabled text-text-disabled",
                         )}
                       >
                         출석
@@ -181,24 +196,18 @@ export default function MainContents(props: IProps) {
                     <button
                       className={twMerge(
                         "w-8 h-8 flex items-center justify-center rounded-lg",
-                        schedule.isTaught ? "bg-bg-tertiary" : "bg-bg-disabled"
+                        schedule.isTaught ? "bg-bg-tertiary" : "bg-bg-disabled",
                       )}
                       onClick={() => {
                         lessonMutation({
                           recordId: schedule.recordId,
-                          isTaught: true,
+                          isTaught: !schedule.isTaught,
                         });
                       }}
-                      disabled={
-                        schedule.recordStatus === "ATTEND" ? false : true
-                      }
+                      disabled={schedule.recordStatus === "ATTEND" ? false : true}
                     >
                       <img
-                        src={`/images/icons/book-check/${
-                          schedule.isTaught
-                            ? "ico-note-active.svg"
-                            : "ico-note.svg"
-                        }`}
+                        src={`/images/icons/book-check/${schedule.isTaught ? "ico-note-active.svg" : "ico-note.svg"}`}
                         alt=""
                       />
                     </button>

--- a/src/pages/books/book-check/components/MainContent.tsx
+++ b/src/pages/books/book-check/components/MainContent.tsx
@@ -217,7 +217,11 @@ export default function MainContents(props: IProps) {
                     <button
                       className={twMerge(
                         "w-8 h-8 flex items-center justify-center rounded-lg",
-                        schedule.isTaught ? "bg-bg-tertiary" : "bg-bg-disabled",
+                        schedule.recordStatus !== "ATTEND"
+                          ? "bg-bg-disabled"
+                          : schedule.isTaught
+                            ? "bg-bg-tertiary"
+                            : "bg-bg-base", // recordStatus === "ATTEND" && isTaught === false 인 경우 bg-bg-base 맞나 ?
                       )}
                       onClick={() => {
                         lessonMutation({

--- a/src/pages/books/book-check/components/MainContent.tsx
+++ b/src/pages/books/book-check/components/MainContent.tsx
@@ -172,7 +172,7 @@ export default function MainContents(props: IProps) {
                       <button
                         onClick={() => {
                           handleCheckedCountChange(schedule, "ATTEND", checkedScheduleCount, setCheckedCount);
-                          handleStatusChange(schedule, "ABSENT", statusMutation, recordMutation);
+                          handleStatusChange(schedule, "ATTEND", statusMutation, recordMutation);
                         }}
                         className={twMerge(
                           "rounded-lg text-sm w-[57px] h-[33px] flex items-center justify-center",

--- a/src/pages/books/book-check/components/MainContent.tsx
+++ b/src/pages/books/book-check/components/MainContent.tsx
@@ -37,29 +37,32 @@ const handleStatusChange = (
   statusMutation: (params: { recordId: number; scheduleId: number; status: STATUS }) => void,
   recordMutation: (params: { attendeeId: number; scheduleId: number; status: STATUS }) => void,
 ) => {
-  if (schedule.recordId) {
-    // 이미 출석인 경우 다시 누르면 PENDING 상태로 수정
-    if (schedule.recordStatus === targetStatus) {
-      statusMutation({
-        recordId: schedule.recordId,
-        scheduleId: schedule.scheduleId,
-        status: "PENDING",
-      });
-    } else {
-      // ATTEND 상태가 아닌 경우 ATTEND 로 변경
-      statusMutation({
-        recordId: schedule.recordId,
-        scheduleId: schedule.scheduleId,
-        status: targetStatus as STATUS,
-      });
-    }
-  } else {
+  // 출석 기록이 없는 경우 출석 기록 생성
+  if (!schedule.recordId) {
     recordMutation({
       attendeeId: schedule.attendeeId,
       scheduleId: schedule.scheduleId,
       status: targetStatus as STATUS,
     });
+    return;
   }
+
+  // 이미 출석인 경우 다시 누르면 PENDING 상태로 수정
+  if (schedule.recordStatus === targetStatus) {
+    statusMutation({
+      recordId: schedule.recordId,
+      scheduleId: schedule.scheduleId,
+      status: "PENDING",
+    });
+    return;
+  }
+
+  // 출석 상태를 targetStatus로 변경
+  statusMutation({
+    recordId: schedule.recordId,
+    scheduleId: schedule.scheduleId,
+    status: targetStatus as STATUS,
+  });
 };
 
 export default function MainContents(props: IProps) {

--- a/src/pages/books/book-check/components/MainContent.tsx
+++ b/src/pages/books/book-check/components/MainContent.tsx
@@ -15,28 +15,38 @@ type IProps = {
   setCheckedCount: (count: number) => void;
 };
 
-const handleCheckedCountChange = (
-  schedule: ScheduleData,
-  targetStatus: Omit<STATUS, "PENDING">,
-  checkedCount: number,
-  setCheckedCount: (count: number) => void,
-) => {
+const handleCheckedCountChange = ({
+  schedule,
+  targetStatus,
+  checkedScheduleCount,
+  setCheckedCount,
+}: {
+  schedule: ScheduleData;
+  targetStatus: Omit<STATUS, "PENDING">;
+  checkedScheduleCount: number;
+  setCheckedCount: (count: number) => void;
+}) => {
   if (!schedule.recordId) {
-    setCheckedCount(checkedCount + 1);
+    setCheckedCount(checkedScheduleCount + 1);
     return;
   }
   const currentStatus = schedule.recordStatus;
-  // 상태 변화에 따른 checkedCount 조정
+  // 상태 변화에 따른 checkedScheduleCount 조정
   const adjustment = currentStatus === targetStatus ? -1 : currentStatus === "PENDING" ? 1 : 0;
-  setCheckedCount(checkedCount + adjustment);
+  setCheckedCount(checkedScheduleCount + adjustment);
 };
 
-const handleStatusChange = (
-  schedule: ScheduleData,
-  targetStatus: Omit<STATUS, "PENDING">,
-  statusMutation: (params: { recordId: number; scheduleId: number; status: STATUS }) => void,
-  recordMutation: (params: { attendeeId: number; scheduleId: number; status: STATUS }) => void,
-) => {
+const handleStatusChange = ({
+  schedule,
+  targetStatus,
+  statusMutation,
+  recordMutation,
+}: {
+  schedule: ScheduleData;
+  targetStatus: Omit<STATUS, "PENDING">;
+  statusMutation: (params: { recordId: number; scheduleId: number; status: STATUS }) => void;
+  recordMutation: (params: { attendeeId: number; scheduleId: number; status: STATUS }) => void;
+}) => {
   // 출석 기록이 없는 경우 출석 기록 생성
   if (!schedule.recordId) {
     recordMutation({
@@ -157,8 +167,18 @@ export default function MainContents(props: IProps) {
                         onClick={() => {
                           // await checkAttendee("", schedule.attendeeId)
                           // statusMutation("REJECTED");`
-                          handleCheckedCountChange(schedule, "ABSENT", checkedScheduleCount, setCheckedCount);
-                          handleStatusChange(schedule, "ABSENT", statusMutation, recordMutation);
+                          handleCheckedCountChange({
+                            schedule,
+                            targetStatus: "ABSENT",
+                            checkedScheduleCount,
+                            setCheckedCount,
+                          });
+                          handleStatusChange({
+                            schedule,
+                            targetStatus: "ABSENT",
+                            statusMutation,
+                            recordMutation,
+                          });
                         }}
                         className={twMerge(
                           "rounded-lg text-sm w-[57px] h-[33px] flex items-center justify-center",
@@ -171,8 +191,18 @@ export default function MainContents(props: IProps) {
                       </button>
                       <button
                         onClick={() => {
-                          handleCheckedCountChange(schedule, "ATTEND", checkedScheduleCount, setCheckedCount);
-                          handleStatusChange(schedule, "ATTEND", statusMutation, recordMutation);
+                          handleCheckedCountChange({
+                            schedule,
+                            targetStatus: "ATTEND",
+                            checkedScheduleCount,
+                            setCheckedCount,
+                          });
+                          handleStatusChange({
+                            schedule,
+                            targetStatus: "ATTEND",
+                            statusMutation,
+                            recordMutation,
+                          });
                         }}
                         className={twMerge(
                           "rounded-lg text-sm w-[57px] h-[33px] flex items-center justify-center",


### PR DESCRIPTION
# Description
1. 헤더의 체크인원/전체인원 기능 추가했습니다.
2. 출석/결석 버튼을 다시 클릭할시 PENDING 상태로 변경 되도록 수정했습니다.
3. 레슨 체크 버튼의 상태를 세 개로 늘렸습니다.
  * Before :  활성/비활성 (상태 2개)
  * After : 비활성/ 활성(체크전) / 활성(체크 후) => 아 부분 bg-bg-base 적용했는데 맞는지 리뷰 한번만 부탁드립니다 !
  
  
# TODO
* 일괄출석 시 checkedCount 가 변경되지 않는데 이부분은 커밋이 커지는 것 같아 자르고 작업하겠습니다.

# Question
1. RecordStatus 에 enum 타입이 아닌  type STATUS = 'ATTEND' | 'PENDING' | 'ABSENT' 를 사용하시는 이유가 있는지 !
  * 단순 궁금증입니다.
2. components 내에서 상태를 변경하기 위해 useEffect 를 사용했는데 이 방법이 맞는 건지 ? 
3. 타입을 지정해도 타입이 안 잡히는 오류가 있던데 ...
